### PR TITLE
Update Messenger

### DIFF
--- a/messenger/darkmode.css
+++ b/messenger/darkmode.css
@@ -606,3 +606,7 @@ body ._wu0 {
 	border: 1px solid #444444;
 }
 /* end */
+
+body ._8slc {
+    color: #e2ded6;
+}


### PR DESCRIPTION
Fixing names of contacts appearing black-on-black when using the search bar in the left panel.

Color used is the same as the one used for the contact name in panel header when in a conversation.

Before :
![before](https://user-images.githubusercontent.com/3795265/70464929-c5e9e980-1ab7-11ea-9690-28ae33c01109.png)

After: (only kept first letter of name in screenshot for privacy purposes)
![after](https://user-images.githubusercontent.com/3795265/70464919-c2eef900-1ab7-11ea-8b96-adfed40d67b7.png)
